### PR TITLE
修复#3，使用MessageBoxA代替AllocConsole

### DIFF
--- a/src/native/tchclient/cefclient/tch_add/TchErrorHandler.cc
+++ b/src/native/tchclient/cefclient/tch_add/TchErrorHandler.cc
@@ -13,13 +13,10 @@ namespace Tnelab{
 		}
 #ifdef OS_WIN
 		if (!error_msg.empty()) {
+			// 弹出错误信息，原来使用AllocConsole但是弹出的控制台窗口不能单独关闭
 			char msg[1024] = { 0 };
 			sprintf(msg, "TCH_ERROR:%d,%s\r\n", error_code, error_msg.c_str());
-			AllocConsole();
-			HANDLE hd = GetStdHandle(STD_OUTPUT_HANDLE);
-			WriteConsoleA(hd, msg, strlen(msg), NULL, NULL);
-			system("pause");
-			CloseHandle(hd);
+			MessageBoxA(NULL, error_msg.c_str(), "Error, press Ctrl+C to copy the details", MB_ICONERROR | MB_OK);
 		}
 #else
 		if (!error_msg.empty())	printf("TCH_ERROR:%d,%s\r\n", error_code, error_msg.c_str());


### PR DESCRIPTION
AllocConsole没有好的办法实现单独关闭
见http://stackoverflow.com/questions/11959643/why-does-closing-a-console-that-was-started-with-allocconsole-cause-my-whole-app