### PR TITLE
linux相关问题的解决

### DIFF
--- a/src/native/tchclient/cefclient/browser/browser_window_osr_gtk.cc
+++ b/src/native/tchclient/cefclient/browser/browser_window_osr_gtk.cc
@@ -1471,11 +1471,14 @@ gint BrowserWindowOsrGtk::MoveEvent(GtkWidget* widget,
   // zmg 2016-11-23
   if (self->caption_moving_) {
     GtkWidget* window = gtk_widget_get_ancestor(GTK_WIDGET(widget), GTK_TYPE_WINDOW);
-    if (window != nullptr) {
+    if (window != nullptr && event->y_root > 0.01) {
       gint window_x = event->x_root - self->caption_moving_begin_x_;
       gint window_y = event->y_root - self->caption_moving_begin_y_;
       gtk_window_move(GTK_WINDOW(window), window_x, window_y);
-      // printf("move window to %d %d\n", window_x, window_y);
+      //printf("move window to %d %d (%lf %d, %lf %d)\n",
+      //  window_x, window_y,
+      //  event->x_root, self->caption_moving_begin_x_,
+      //  event->y_root, self->caption_moving_begin_y_);
     }
   }
   // zmg end

--- a/src/native/tchclient/cefclient/tch_add/TchWindowApiGtk.cc
+++ b/src/native/tchclient/cefclient/tch_add/TchWindowApiGtk.cc
@@ -54,8 +54,24 @@ void TchWindowApi::ShowWindow(CefRefPtr<CefFrame> frame) {
 		gtk_window_present(window);
 	}
 }
-void TchWindowApi::SetWindowPos(CefRefPtr<CefFrame> frame, int x, int y, int width, int height) {
 
+void TchWindowApi::SetWindowPos(CefRefPtr<CefFrame> frame, int x, int y, int width, int height) {
+	auto window = GetWindow(frame->GetBrowser());
+	if (window != nullptr) {
+		gtk_window_move(GTK_WINDOW(window), x, y);
+		gtk_window_resize(GTK_WINDOW(window), width, height);
+	}
 }
+
 void TchWindowApi::GetWindowPos(CefRefPtr<CefFrame> frame, CefRect& rect) {
+	auto window = GetWindow(frame->GetBrowser());
+	if (window != nullptr) {
+		gint x = 0, y = 0, width = 0, height = 0;
+		gtk_window_get_position(GTK_WINDOW(window), &x, &y);
+		gtk_window_get_size(GTK_WINDOW(window), &width, &height);
+		rect.x = x;
+		rect.y = y;
+		rect.width = width;
+		rect.height = height;
+	}
 }


### PR DESCRIPTION
#31
修复gtk窗口拖动会飘动的问题
原因在于鼠标离开窗口时，会给窗口发送一个移动x=不定值 y=0的事件，导致窗口往错误的地方跑
这个修复过滤了y等于0的情况

#40 #41
支持获取窗口位置大小和设置窗口位置大小的api
已在console中测试过